### PR TITLE
ci: temporarily disable failing NXF_VER 25.10.4 matrix and lint checks

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   pre-commit:
+    # temporarily disabled - failing, re-enable once fixed (see docs/decisions.md)
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -20,6 +22,8 @@ jobs:
         uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2
 
   nf-core:
+    # temporarily disabled - failing, re-enable once fixed (see docs/decisions.md)
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Check out pipeline code

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -76,7 +76,7 @@ jobs:
           - isMain: false
             profile: "singularity"
         NXF_VER:
-          - "25.10.4"
+          # "25.10.4" temporarily disabled - failing, re-enable once fixed (see docs/decisions.md)
           - "latest-everything"
     env:
       NXF_ANSI_LOG: false


### PR DESCRIPTION
This pull request temporarily disables certain failing CI jobs and test configurations in the GitHub Actions workflows. The changes are intended to prevent CI failures while issues are being investigated, with instructions to re-enable once fixed.

**CI job disabling:**

* Disabled the `pre-commit` job in `.github/workflows/linting.yml` by adding `if: false` and a comment referencing the decision documentation.
* Disabled the `nf-core` job in `.github/workflows/linting.yml` by adding `if: false` and a similar comment.

**Test matrix adjustment:**

* Commented out the `"25.10.4"` version in the `NXF_VER` test matrix in `.github/workflows/nf-test.yml` to temporarily skip this failing configuration, with a note to re-enable once fixed.